### PR TITLE
Remove the default ECR policy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -43,27 +43,6 @@ data "aws_iam_policy_document" "read" {
   }
 }
 
-data "aws_iam_policy_document" "default" {
-  statement {
-    sid    = "ecr"
-    effect = "Allow"
-
-    actions = [
-      "ecr:BatchCheckLayerAvailability",
-      "ecr:BatchGetImage",
-      "ecr:CompleteLayerUpload",
-      "ecr:DescribeImages",
-      "ecr:DescribeRepositories",
-      "ecr:GetAuthorizationToken",
-      "ecr:GetDownloadUrlForLayer",
-      "ecr:InitiateLayerUpload",
-      "ecr:ListImages",
-      "ecr:PutImage",
-      "ecr:UploadLayerPart",
-    ]
-  }
-}
-
 module "label" {
   source = "git::https://github.com/MITLibraries/tf-mod-name?ref=master"
   name   = "${var.name}"
@@ -90,12 +69,6 @@ resource "aws_iam_policy" "write" {
   name        = "${module.label.name}-write"
   description = "Allow IAM Users to push into ECR"
   policy      = "${data.aws_iam_policy_document.write.json}"
-}
-
-resource "aws_iam_policy" "default" {
-  name        = "${module.label.name}-default"
-  description = "Allow IAM Users to push/pull from ECR"
-  policy      = "${data.aws_iam_policy_document.default.json}"
 }
 
 resource "aws_ecr_lifecycle_policy" "default" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -42,13 +42,3 @@ output "policy_write_arn" {
   value       = "${aws_iam_policy.write.arn}"
   description = "The IAM Policy ARN to be given access to push images to ECR"
 }
-
-output "policy_default_name" {
-  value       = "${aws_iam_policy.default.name}"
-  description = "The IAM Policy name to be given access to push/pull images from ECR"
-}
-
-output "policy_default_arn" {
-  value       = "${aws_iam_policy.default.arn}"
-  description = "The IAM Policy ARN to be given acces to push/pull images from ECR"
-}


### PR DESCRIPTION
This policy is broken because it's missing a resource, which is
required. We could attach a resource to it, but the
GetAuthorizationToken action can only be attached to the `*` resource.
I'm not sure why we need this policy anyways since the other policies
cover everything it offers.