### PR TITLE
Add read/write ECR policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,28 @@
-This module is used to create an [`AWS ECR Docker Container registry`](https://aws.amazon.com/ecr/).
-It is originally from [here](https://github.com/cloudposse/terraform-aws-ecr), and has been modified to fit our needs.
+# Terraform ECR module
 
-You can either provide an existing role or this module will create the require roles and policies.
+This module is used to create an [`AWS ECR Docker Container registry`](https://aws.amazon.com/ecr/). It is originally from [here](https://github.com/cloudposse/terraform-aws-ecr), and has been modified to fit our needs.
 
 ## Inputs
 
-| Name            | Description                                                           |  Type  |  Default | Required |
-| --------------- | --------------------------------------------------------------------- | :----: | :------: | :------: |
-| max_image_count | How many Docker Image versions AWS ECR will store                     | string |    `5`   |    no    |
-| name            | The Name of the application or solution  (e.g. `bastion` or `portal`) | string |     -    |    yes   |
-| roles           | Principal IAM roles to provide with access to the ECR                 |  list  | `<list>` |    no    |
-| tags            | Additional tags (e.g. `map('BusinessUnit','XYZ')`)                    |   map  |  `<map>` |    no    |
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| max\_image\_count | How many Docker Image versions AWS ECR will store | string | `5` | no |
+| name | The Name of the application or solution  (e.g. `bastion` or `portal`) | string | - | yes |
+| tags | Additional tags (e.g. `map('BusinessUnit','XYZ')`) | map | `<map>` | no |
 
 ## Outputs
 
-| Name              | Description                                                    |
-| ----------------- | -------------------------------------------------------------- |
-| policy_login_arn  | The IAM Policy ARN to be given access to login in ECR          |
-| policy_login_name | The IAM Policy name to be given access to login in ECR         |
-| policy_read_arn   | The IAM Policy ARN to be given access to pull images from ECR  |
-| policy_read_name  | The IAM Policy name to be given access to pull images from ECR |
-| policy_write_arn  | The IAM Policy ARN to be given access to push images to ECR    |
-| policy_write_name | The IAM Policy name to be given access to push images to ECR   |
-| registry_id       | Registry ID                                                    |
-| registry_url      | Registry URL                                                   |
-| repository_name   | Registry name                                                  |
-| role_arn          | Assume Role ARN to get registry access                         |
-| role_name         | Assume Role name to get registry access                        |
+| Name | Description |
+|------|-------------|
+| policy\_login\_arn | The IAM Policy ARN to be given access to login in ECR |
+| policy\_login\_name | The IAM Policy name to be given access to login in ECR |
+| policy\_read\_arn | The IAM Policy ARN to be given access to pull images from ECR |
+| policy\_read\_name | The IAM Policy name to be given access to pull images from ECR |
+| policy\_readwrite\_arn | The IAM policy ARN to be given read/write access to ECR |
+| policy\_readwrite\_name | The IAM policy name to be given read/write access to ECR |
+| policy\_write\_arn | The IAM Policy ARN to be given access to push images to ECR |
+| policy\_write\_name | The IAM Policy name to be given access to push images to ECR |
+| registry\_id | Registry ID |
+| registry\_url | Registry URL |
+| repository\_name | Registry name |
+

--- a/outputs.tf
+++ b/outputs.tf
@@ -42,3 +42,13 @@ output "policy_write_arn" {
   value       = "${aws_iam_policy.write.arn}"
   description = "The IAM Policy ARN to be given access to push images to ECR"
 }
+
+output "policy_readwrite_name" {
+  value       = "${aws_iam_policy.readwrite.name}"
+  description = "The IAM policy name to be given read/write access to ECR"
+}
+
+output "policy_readwrite_arn" {
+  value       = "${aws_iam_policy.readwrite.arn}"
+  description = "The IAM policy ARN to be given read/write access to ECR"
+}


### PR DESCRIPTION
This creates a single read/write policy rather than having to use a
combination of three different policies. In most cases, this is the
policy we would use, so this will make using it easier.

I have also refined the list of actions based on the documentation to
reflect what seems like the appropriate and necessary permissions.